### PR TITLE
Fix minimal code example to use raster()

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ fn main() {
     let char_raster =
         get_raster('A', FontWeight::Regular, RasterHeight::Size16).expect("unsupported char");
     println!("{:?}", char_raster);
-    for (row_i, row) in char_raster.bitmap().iter().enumerate() {
+    for (row_i, row) in char_raster.raster().iter().enumerate() {
         for (col_i, pixel) in row.iter().enumerate() {
             println!("[{:02}][{:02}]: {:03}", row_i, col_i, pixel);
         }


### PR DESCRIPTION
Change the call to bitmap() to raster() so it works with current crate code. This makes the example consistent with the code in the examples/ folder.

**NOTE: The same change needs to be made to the [crates.io](https://crates.io/crates/noto-sans-mono-bitmap) page.**